### PR TITLE
feat: renamed acctId and LoanId fields to "id" for consistency

### DIFF
--- a/src/main/frontend/src/App.tsx
+++ b/src/main/frontend/src/App.tsx
@@ -71,8 +71,8 @@ function App() {
                 </TableHeader>
                 <TableBody>
                     {accounts.map((account) => (
-                        <TableRow key={account.acctId} onClick={() => {navigate(`/account/${account.acctId}`)}} className={"cursor-pointer"}>
-                            <TableCell>{account.acctId}</TableCell>
+                        <TableRow key={account.id} onClick={() => {navigate(`/account/${account.id}`)}} className={"cursor-pointer"}>
+                            <TableCell>{account.id}</TableCell>
                             <TableCell>{account.userType}</TableCell>
                             <TableCell>{account.username}</TableCell>
                             <TableCell>{account.password}</TableCell>

--- a/src/main/frontend/src/vite-env.d.ts
+++ b/src/main/frontend/src/vite-env.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="vite/client" />
 
 interface Account {
-    acctId: number;
+    id: number;
     userType: number;
     username: string;
     password: string;

--- a/src/main/java/com/avengers/example/domain/Account.java
+++ b/src/main/java/com/avengers/example/domain/Account.java
@@ -12,7 +12,7 @@ public class Account
 {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long acctId;
+    private long id;  // primary key for the account table (renamed for compatibility).
     private int userType;
     private String username;
     private String password;

--- a/src/main/java/com/avengers/example/domain/Loan.java
+++ b/src/main/java/com/avengers/example/domain/Loan.java
@@ -12,7 +12,7 @@ public class Loan
 {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long loanId;
+    private Long id; // primary key for the loan table (renamed for compatibility).
     private double originAmount;
     private long interestRate;
 
@@ -26,14 +26,14 @@ public class Loan
         this.interestRate = interestRate;
     }
 
-    public void setLoanId(Long loanId)
+    public void setId(Long loanId)
     {
-        this.loanId = loanId;
+        this.id = loanId;
     }
 
-    public Long getLoanId()
+    public Long getId()
     {
-        return loanId;
+        return id;
     }
 
     public void setOriginAmount(double originAmount)


### PR DESCRIPTION
The frontend will contain a lot of code similar to this:
```js
account.acctId
loan.loanId
``` 
This code is used often when filling out the ui and filtering cache requests. I believe the following to be a better naming choice for expression and it's slightly more concise
```js
account.id
loan.id
```