### PR TITLE
fix maven.yml + separate building/testing

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -31,6 +31,7 @@ jobs:
     - name: Run Java Tests
       run: mvn -B test --file pom.xml
 
+    # not functional for some reason with the current setup
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
-    - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@v4
+    #- name: Update dependency graph
+    #  uses: advanced-security/maven-dependency-submission-action@v4

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,9 +25,12 @@ jobs:
         java-version: '17'
         distribution: 'temurin'
         cache: maven
-    - name: Build with Maven
-      run: mvn clean install -B package --file pom.xml
+    - name: Compile Java Source
+      run: mvn -B compile --file pom.xml
+
+    - name: Run Java Tests
+      run: mvn -B test --file pom.xml
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@571e99aab1055c2e71a1e2309b9691de18d6b7d6
+      uses: advanced-security/maven-dependency-submission-action@v4

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.3.3</version>
+		<version>3.3.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.avengers</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
 					</excludes>
 				</configuration>
 			</plugin>
+			<plugin>
+				<groupId>com.github.ferstl</groupId>
+				<artifactId>depgraph-maven-plugin</artifactId>
+				<version>4.0.3</version>
+			</plugin>
 		</plugins>
 	</build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -80,11 +80,6 @@
 					</excludes>
 				</configuration>
 			</plugin>
-			<plugin>
-				<groupId>com.github.ferstl</groupId>
-				<artifactId>depgraph-maven-plugin</artifactId>
-				<version>4.0.3</version>
-			</plugin>
 		</plugins>
 	</build>
 


### PR DESCRIPTION
**See issue #10**

removed `clean`, `install`, and `package` commands from build and replaced with `compile` and `test` in separate steps for readability when the action fails. 